### PR TITLE
Release 1.9.2pp

### DIFF
--- a/lang/java/archetypes/avro-service-archetype/pom.xml
+++ b/lang/java/archetypes/avro-service-archetype/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-archetypes-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2.1pp</version>
+    <version>1.9.2.2pp</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/lang/java/archetypes/avro-service-archetype/pom.xml
+++ b/lang/java/archetypes/avro-service-archetype/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-archetypes-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2</version>
+    <version>1.9.2pp</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/lang/java/archetypes/avro-service-archetype/pom.xml
+++ b/lang/java/archetypes/avro-service-archetype/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-archetypes-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2pp</version>
+    <version>1.9.2.1pp</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/lang/java/archetypes/pom.xml
+++ b/lang/java/archetypes/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.avro</groupId>
     <artifactId>avro-parent</artifactId>
-    <version>1.9.2</version>
+    <version>1.9.2pp</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/lang/java/archetypes/pom.xml
+++ b/lang/java/archetypes/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.avro</groupId>
     <artifactId>avro-parent</artifactId>
-    <version>1.9.2.1pp</version>
+    <version>1.9.2.2pp</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/lang/java/archetypes/pom.xml
+++ b/lang/java/archetypes/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.avro</groupId>
     <artifactId>avro-parent</artifactId>
-    <version>1.9.2pp</version>
+    <version>1.9.2.1pp</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/lang/java/avro/pom.xml
+++ b/lang/java/avro/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2pp</version>
+    <version>1.9.2.1pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/avro/pom.xml
+++ b/lang/java/avro/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2.1pp</version>
+    <version>1.9.2.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -29,8 +29,26 @@ import org.apache.avro.util.internal.Accessor;
 import org.apache.avro.util.internal.Accessor.FieldAccessor;
 import org.apache.avro.util.internal.JacksonUtils;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 /**
  * An abstract data type.
@@ -1532,49 +1550,49 @@ public abstract class Schema extends JsonProperties implements Serializable {
     if (defaultValue == null)
       return false;
     switch (schema.getType()) {
-      case STRING:
-      case BYTES:
-      case ENUM:
-      case FIXED:
-        return defaultValue.isTextual();
-      case INT:
-      case LONG:
-      case FLOAT:
-      case DOUBLE:
-        return defaultValue.isNumber();
-      case BOOLEAN:
-        return defaultValue.isBoolean();
-      case NULL:
-        return defaultValue.isNull();
-      case ARRAY:
-        if (!defaultValue.isArray())
-          return false;
-        for (JsonNode element : defaultValue)
-          if (!isValidDefault(schema.getElementType(), element, true))
-            return false;
-        return true;
-      case MAP:
-        if (!defaultValue.isObject())
-          return false;
-        for (JsonNode value : defaultValue)
-          if (!isValidDefault(schema.getValueType(), value, true))
-            return false;
-        return true;
-      case UNION:
-        return elementCheck
-          ? isValidDefault(schema.getTypes().get(0), defaultValue)
-          || isValidDefault(schema.getTypes().get(1), defaultValue)
-          : isValidDefault(schema.getTypes().get(0), defaultValue);
-      case RECORD:
-        if (!defaultValue.isObject())
-          return false;
-        for (Field field : schema.getFields())
-          if (!isValidDefault(field.schema(),
-            defaultValue.has(field.name()) ? defaultValue.get(field.name()) : field.defaultValue(), true))
-            return false;
-        return true;
-      default:
+    case STRING:
+    case BYTES:
+    case ENUM:
+    case FIXED:
+      return defaultValue.isTextual();
+    case INT:
+    case LONG:
+    case FLOAT:
+    case DOUBLE:
+      return defaultValue.isNumber();
+    case BOOLEAN:
+      return defaultValue.isBoolean();
+    case NULL:
+      return defaultValue.isNull();
+    case ARRAY:
+      if (!defaultValue.isArray())
         return false;
+      for (JsonNode element : defaultValue)
+        if (!isValidDefault(schema.getElementType(), element, true))
+          return false;
+      return true;
+    case MAP:
+      if (!defaultValue.isObject())
+        return false;
+      for (JsonNode value : defaultValue)
+        if (!isValidDefault(schema.getValueType(), value, true))
+          return false;
+      return true;
+    case UNION:
+      return elementCheck
+          ? isValidDefault(schema.getTypes().get(0), defaultValue)
+              || isValidDefault(schema.getTypes().get(1), defaultValue)
+          : isValidDefault(schema.getTypes().get(0), defaultValue);
+    case RECORD:
+      if (!defaultValue.isObject())
+        return false;
+      for (Field field : schema.getFields())
+        if (!isValidDefault(field.schema(),
+            defaultValue.has(field.name()) ? defaultValue.get(field.name()) : field.defaultValue(), true))
+          return false;
+      return true;
+    default:
+      return false;
     }
   }
 

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/AvroName.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/AvroName.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
  * Sets the avroname for this java field. When reading into this class, a
  * reflectdatumreader looks for a schema field with the avroname.
  */
-@Target(ElementType.FIELD)
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface AvroName {
   String value();

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
@@ -819,6 +819,7 @@ public class ReflectData extends SpecificData {
           genericTypeMap.getOrDefault(parameter.getParameterizedType(),
               parameter.getParameterizedType() != null ? parameter.getParameterizedType() : parameter.getType()),
           names);
+      String paramName = parameter.getName();
       for (Annotation annotation : parameter.getAnnotations()) {
         if (annotation instanceof AvroSchema) // explicit schema
           paramSchema = new Schema.Parser().parse(((AvroSchema) annotation).value());
@@ -826,8 +827,10 @@ public class ReflectData extends SpecificData {
           paramSchema = getAnnotatedUnion(((Union) annotation), names);
         else if (annotation instanceof Nullable) // nullable
           paramSchema = makeNullable(paramSchema);
+        else if (annotation instanceof AvroName)
+          paramName = ((AvroName) annotation).value();
       }
-      fields.add(new Schema.Field(parameter.getName(), paramSchema, null /* doc */, null));
+      fields.add(new Schema.Field(paramName, paramSchema, null /* doc */, null));
     }
 
     Schema request = Schema.createRecord(fields);

--- a/lang/java/avro/src/main/java/org/apache/avro/util/internal/JacksonUtils.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/util/internal/JacksonUtils.java
@@ -27,7 +27,12 @@ import org.apache.avro.Schema;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 public class JacksonUtils {
 

--- a/lang/java/compiler/pom.xml
+++ b/lang/java/compiler/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2pp</version>
+    <version>1.9.2.1pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/compiler/pom.xml
+++ b/lang/java/compiler/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2</version>
+    <version>1.9.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/compiler/pom.xml
+++ b/lang/java/compiler/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2.1pp</version>
+    <version>1.9.2.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/grpc/pom.xml
+++ b/lang/java/grpc/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.avro</groupId>
     <artifactId>avro-parent</artifactId>
-    <version>1.9.2pp</version>
+    <version>1.9.2.1pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/grpc/pom.xml
+++ b/lang/java/grpc/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.avro</groupId>
     <artifactId>avro-parent</artifactId>
-    <version>1.9.2.1pp</version>
+    <version>1.9.2.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/grpc/pom.xml
+++ b/lang/java/grpc/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.avro</groupId>
     <artifactId>avro-parent</artifactId>
-    <version>1.9.2</version>
+    <version>1.9.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/integration-test/codegen-test/pom.xml
+++ b/lang/java/integration-test/codegen-test/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-integration-test</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2pp</version>
+    <version>1.9.2.1pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/integration-test/codegen-test/pom.xml
+++ b/lang/java/integration-test/codegen-test/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-integration-test</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2.1pp</version>
+    <version>1.9.2.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/integration-test/codegen-test/pom.xml
+++ b/lang/java/integration-test/codegen-test/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-integration-test</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2</version>
+    <version>1.9.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/integration-test/pom.xml
+++ b/lang/java/integration-test/pom.xml
@@ -23,7 +23,7 @@
   <parent>
       <artifactId>avro-parent</artifactId>
       <groupId>org.apache.avro</groupId>
-      <version>1.9.2</version>
+      <version>1.9.2pp</version>
       <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/integration-test/pom.xml
+++ b/lang/java/integration-test/pom.xml
@@ -23,7 +23,7 @@
   <parent>
       <artifactId>avro-parent</artifactId>
       <groupId>org.apache.avro</groupId>
-      <version>1.9.2.1pp</version>
+      <version>1.9.2.2pp</version>
       <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/integration-test/pom.xml
+++ b/lang/java/integration-test/pom.xml
@@ -23,7 +23,7 @@
   <parent>
       <artifactId>avro-parent</artifactId>
       <groupId>org.apache.avro</groupId>
-      <version>1.9.2pp</version>
+      <version>1.9.2.1pp</version>
       <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/integration-test/test-custom-conversions/pom.xml
+++ b/lang/java/integration-test/test-custom-conversions/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-integration-test</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2pp</version>
+    <version>1.9.2.1pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/integration-test/test-custom-conversions/pom.xml
+++ b/lang/java/integration-test/test-custom-conversions/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-integration-test</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2.1pp</version>
+    <version>1.9.2.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/integration-test/test-custom-conversions/pom.xml
+++ b/lang/java/integration-test/test-custom-conversions/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-integration-test</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2</version>
+    <version>1.9.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/ipc-jetty/pom.xml
+++ b/lang/java/ipc-jetty/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2pp</version>
+    <version>1.9.2.1pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/ipc-jetty/pom.xml
+++ b/lang/java/ipc-jetty/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2</version>
+    <version>1.9.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/ipc-jetty/pom.xml
+++ b/lang/java/ipc-jetty/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2.1pp</version>
+    <version>1.9.2.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/ipc-netty/pom.xml
+++ b/lang/java/ipc-netty/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2pp</version>
+    <version>1.9.2.1pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/ipc-netty/pom.xml
+++ b/lang/java/ipc-netty/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2</version>
+    <version>1.9.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/ipc-netty/pom.xml
+++ b/lang/java/ipc-netty/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2.1pp</version>
+    <version>1.9.2.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/ipc/pom.xml
+++ b/lang/java/ipc/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2pp</version>
+    <version>1.9.2.1pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/ipc/pom.xml
+++ b/lang/java/ipc/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2</version>
+    <version>1.9.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/ipc/pom.xml
+++ b/lang/java/ipc/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2.1pp</version>
+    <version>1.9.2.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/mapred/pom.xml
+++ b/lang/java/mapred/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2pp</version>
+    <version>1.9.2.1pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/mapred/pom.xml
+++ b/lang/java/mapred/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2</version>
+    <version>1.9.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/mapred/pom.xml
+++ b/lang/java/mapred/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2.1pp</version>
+    <version>1.9.2.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/maven-plugin/pom.xml
+++ b/lang/java/maven-plugin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2pp</version>
+    <version>1.9.2.1pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/maven-plugin/pom.xml
+++ b/lang/java/maven-plugin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2</version>
+    <version>1.9.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/maven-plugin/pom.xml
+++ b/lang/java/maven-plugin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2.1pp</version>
+    <version>1.9.2.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/perf/pom.xml
+++ b/lang/java/perf/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2pp</version>
+    <version>1.9.2.1pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/perf/pom.xml
+++ b/lang/java/perf/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2</version>
+    <version>1.9.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/perf/pom.xml
+++ b/lang/java/perf/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2.1pp</version>
+    <version>1.9.2.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.avro</groupId>
     <artifactId>avro-toplevel</artifactId>
-    <version>1.9.2</version>
+    <version>1.9.2pp</version>
     <relativePath>../../</relativePath>
   </parent>
 

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.avro</groupId>
     <artifactId>avro-toplevel</artifactId>
-    <version>1.9.2.1pp</version>
+    <version>1.9.2.2pp</version>
     <relativePath>../../</relativePath>
   </parent>
 

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.avro</groupId>
     <artifactId>avro-toplevel</artifactId>
-    <version>1.9.2pp</version>
+    <version>1.9.2.1pp</version>
     <relativePath>../../</relativePath>
   </parent>
 

--- a/lang/java/protobuf/pom.xml
+++ b/lang/java/protobuf/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2pp</version>
+    <version>1.9.2.1pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/protobuf/pom.xml
+++ b/lang/java/protobuf/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2</version>
+    <version>1.9.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/protobuf/pom.xml
+++ b/lang/java/protobuf/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2.1pp</version>
+    <version>1.9.2.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/thrift/pom.xml
+++ b/lang/java/thrift/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2pp</version>
+    <version>1.9.2.1pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/thrift/pom.xml
+++ b/lang/java/thrift/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2</version>
+    <version>1.9.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/thrift/pom.xml
+++ b/lang/java/thrift/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2.1pp</version>
+    <version>1.9.2.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/tools/pom.xml
+++ b/lang/java/tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2pp</version>
+    <version>1.9.2.1pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/tools/pom.xml
+++ b/lang/java/tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2</version>
+    <version>1.9.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/tools/pom.xml
+++ b/lang/java/tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2.1pp</version>
+    <version>1.9.2.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/trevni/avro/pom.xml
+++ b/lang/java/trevni/avro/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>trevni-java</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2pp</version>
+    <version>1.9.2.1pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/trevni/avro/pom.xml
+++ b/lang/java/trevni/avro/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>trevni-java</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2.1pp</version>
+    <version>1.9.2.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/trevni/avro/pom.xml
+++ b/lang/java/trevni/avro/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>trevni-java</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2</version>
+    <version>1.9.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/trevni/core/pom.xml
+++ b/lang/java/trevni/core/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>trevni-java</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2pp</version>
+    <version>1.9.2.1pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/trevni/core/pom.xml
+++ b/lang/java/trevni/core/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>trevni-java</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2.1pp</version>
+    <version>1.9.2.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/trevni/core/pom.xml
+++ b/lang/java/trevni/core/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>trevni-java</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2</version>
+    <version>1.9.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/trevni/doc/pom.xml
+++ b/lang/java/trevni/doc/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>trevni-java</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2pp</version>
+    <version>1.9.2.1pp</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lang/java/trevni/doc/pom.xml
+++ b/lang/java/trevni/doc/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>trevni-java</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2</version>
+    <version>1.9.2pp</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lang/java/trevni/doc/pom.xml
+++ b/lang/java/trevni/doc/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>trevni-java</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2.1pp</version>
+    <version>1.9.2.2pp</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lang/java/trevni/pom.xml
+++ b/lang/java/trevni/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2pp</version>
+    <version>1.9.2.1pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/trevni/pom.xml
+++ b/lang/java/trevni/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2</version>
+    <version>1.9.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/trevni/pom.xml
+++ b/lang/java/trevni/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.9.2.1pp</version>
+    <version>1.9.2.2pp</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
   <groupId>org.apache.avro</groupId>
   <artifactId>avro-toplevel</artifactId>
-  <version>1.9.2pp</version>
+  <version>1.9.2.1pp</version>
   <packaging>pom</packaging>
 
   <name>Apache Avro Toplevel</name>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
   <groupId>org.apache.avro</groupId>
   <artifactId>avro-toplevel</artifactId>
-  <version>1.9.2.1pp</version>
+  <version>1.9.2.2pp</version>
   <packaging>pom</packaging>
 
   <name>Apache Avro Toplevel</name>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
   <groupId>org.apache.avro</groupId>
   <artifactId>avro-toplevel</artifactId>
-  <version>1.9.2</version>
+  <version>1.9.2pp</version>
   <packaging>pom</packaging>
 
   <name>Apache Avro Toplevel</name>


### PR DESCRIPTION
Create unions with null types in a way that they respect the default value type.
Use parametrized types when available during parameter schema creation for ipc protocols.
Allow explicit naming of method parameters in protocol to work around the breaking change in generation of protocols caused by removal of Paranamer dependency.
Using avro's lint before commit.